### PR TITLE
Feat: proposal comments db schema

### DIFF
--- a/packages/api/src/root.ts
+++ b/packages/api/src/root.ts
@@ -1,8 +1,10 @@
 import { moduleRouter } from "./router/module";
+import { proposalCommentRouter } from "./router/proposal-comment";
 import { createTRPCRouter } from "./trpc";
 
 export const appRouter = createTRPCRouter({
   module: moduleRouter,
+  proposalComment: proposalCommentRouter,
 });
 
 // export type definition of API

--- a/packages/api/src/router/proposal-comment.ts
+++ b/packages/api/src/router/proposal-comment.ts
@@ -1,0 +1,58 @@
+import type { TRPCRouterRecord } from "@trpc/server";
+import { z } from "zod";
+
+import { eq, sql } from "@commune-ts/db";
+import {
+  proposalCommentDigestView,
+  proposalCommentSchema,
+  commentInteractionSchema,
+  commentReportSchema
+} from "@commune-ts/db/schema";
+
+import {
+  COMMENT_INTERACTION_INSERT_SCHEMA,
+  COMMENT_REPORT_INSERT_SCHEMA,
+  PROPOSAL_COMMENT_INSERT_SCHEMA
+} from "@commune-ts/db/validation";
+
+import { publicProcedure } from "../trpc";
+
+export const proposalCommentRouter = {
+  // GET
+  byProposalId: publicProcedure
+    .input(z.object({ proposalId: z.number() }))
+    .query(({ ctx, input }) => {
+    return ctx.db.select().from(proposalCommentDigestView).where(
+      eq(proposalCommentDigestView.proposalId, input.proposalId)).execute();
+  }),
+  // POST
+  createComment: publicProcedure
+    .input(PROPOSAL_COMMENT_INSERT_SCHEMA)
+    .mutation(async ({ ctx, input }) => {
+      await ctx.db.insert(proposalCommentSchema).values(input);
+    }),
+  createCommentReport: publicProcedure
+    .input(COMMENT_REPORT_INSERT_SCHEMA)
+    .mutation(async ({ ctx, input }) => {
+      await ctx.db.insert(commentReportSchema).values(input);
+    }),
+  castVote: publicProcedure
+    .input(COMMENT_INTERACTION_INSERT_SCHEMA)
+    .mutation(async ({ ctx, input }) => {
+      await ctx.db.insert(commentInteractionSchema).values(input).onConflictDoUpdate({
+        target: [commentInteractionSchema.commentId, commentInteractionSchema.userKey],
+        set: {
+          voteType: input.voteType,
+        },
+      });
+    }),
+  deleteVote: publicProcedure
+    .input(z.object({ commentId: z.string(), userKey: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      await ctx.db
+        .delete(commentInteractionSchema)
+        .where(
+          sql`${commentInteractionSchema.commentId} = ${input.commentId} AND ${commentInteractionSchema.userKey} = ${input.userKey}`,
+        );
+  }),
+} satisfies TRPCRouterRecord;

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -15,6 +15,10 @@
     "./schema": {
       "types": "./dist/schema.d.ts",
       "default": "./src/schema.ts"
+    },
+    "./validation": {
+      "types": "./dist/validation.d.ts",
+      "default": "./src/validation.ts"
     }
   },
   "license": "MIT",

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,4 +1,4 @@
-import { asc, eq, sql } from "drizzle-orm";
+import { asc, eq, is, sql } from "drizzle-orm";
 import {
   bigint,
   integer,
@@ -10,7 +10,7 @@ import {
   varchar,
   uuid,
   index,
-  pgMaterializedView
+  pgView
 } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
@@ -161,7 +161,7 @@ export const commentInteractionSchema = createTable("comment_interaction", {
  * This view computes the number of upvotes and downvotes for each comment at write time. 
  * so that we can query the data more efficiently.
  */
-export const proposalCommentDigestView = pgMaterializedView("comment_digest").as(
+export const proposalCommentDigestView = pgView("comment_digest").as(
   qb => qb
     .select({
       id: proposalCommentSchema.id,
@@ -188,7 +188,7 @@ export const proposalCommentDigestView = pgMaterializedView("comment_digest").as
 /**
  * A report made by a user about comment.
  */
-export const commentReport = createTable("comment_report", {
+export const commentReportSchema = createTable("comment_report", {
   id: serial("id").primaryKey(),
   userKey: ss58Address("user_key"),
   commentId: uuid("comment_id")

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -135,3 +135,21 @@ export const proposalCommentSchema = createTable("proposal_comment", {
 }, (t) => ({
   proposalIdIndex: index("proposal_id_index").on(t.proposalId),
 }));
+
+export enum VoteType {
+  UP = "UP",
+  DOWN = "DOWN",
+}
+
+export const commentInteractionSchema = createTable("comment_interaction", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  commentId: uuid("comment_id")
+    .references(() => proposalCommentSchema.id).notNull(),
+  userKey: ss58Address("user_key").notNull(),
+  voteType: varchar("vote_type", { length: 4 }).notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+}, (t) => ({
+  unq: unique().on(t.commentId, t.userKey),
+  commentIdIndex: index("comment_id_index").on(t.commentId),
+  commentVoteIndex: index("comment_vote_index").on(t.commentId, t.voteType),
+}),);

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -8,6 +8,8 @@ import {
   timestamp,
   unique,
   varchar,
+  uuid,
+  index,
 } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
@@ -122,3 +124,14 @@ export const moduleReportPostSchema = createInsertSchema(moduleReport, {
 }).omit({
   id: true,
 });
+
+export const proposalCommentSchema = createTable("proposal_comment", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  proposalId: integer("proposal_id").notNull(),
+  userKey: ss58Address("user_key").notNull(),
+  content: text("content").notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  deletedAt: timestamp("deleted_at").default(sql`null`),
+}, (t) => ({
+  proposalIdIndex: index("proposal_id_index").on(t.proposalId),
+}));

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,4 +1,4 @@
-import { sql } from "drizzle-orm";
+import { asc, eq, sql } from "drizzle-orm";
 import {
   bigint,
   integer,
@@ -153,3 +153,17 @@ export const commentInteractionSchema = createTable("comment_interaction", {
   commentIdIndex: index("comment_id_index").on(t.commentId),
   commentVoteIndex: index("comment_vote_index").on(t.commentId, t.voteType),
 }),);
+
+/**
+ * A report made by a user about comment.
+ */
+export const commentReport = createTable("comment_report", {
+  id: serial("id").primaryKey(),
+  userKey: ss58Address("user_key"),
+  commentId: uuid("comment_id")
+    .references(() => proposalCommentSchema.id)
+    .notNull(),
+  content: text("content"),
+  reason: varchar("reason", { length: 16 }),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});

--- a/packages/db/src/validation.ts
+++ b/packages/db/src/validation.ts
@@ -1,0 +1,32 @@
+import { createInsertSchema } from "drizzle-zod";
+import { commentInteractionSchema, proposalCommentSchema, VoteType, commentReportSchema, ReportReason} from "./schema";
+import { z } from "zod";
+
+export const PROPOSAL_COMMENT_INSERT_SCHEMA = createInsertSchema(proposalCommentSchema, {
+  content: z.string().min(1).max(512).transform((v) => v.trim()).refine(s => s.length, "Comment should not be blank"),
+  userKey: z.string().min(1),
+  proposalId: z.number().int(),
+}).omit({
+  id: true,
+  createdAt: true,
+  deletedAt: true,
+});
+
+export const COMMENT_INTERACTION_INSERT_SCHEMA = createInsertSchema(commentInteractionSchema, {
+  commentId: z.string(),
+  userKey: z.string(),
+  voteType: z.nativeEnum(VoteType),
+}).omit({
+  id: true,
+  createdAt: true,
+});
+
+export const COMMENT_REPORT_INSERT_SCHEMA = createInsertSchema(commentReportSchema, {
+  commentId: z.string(),
+  userKey: z.string(),
+  reason: z.nativeEnum(ReportReason),
+  content: z.string().min(1).max(512).transform((v) => v.trim()).refine(s => s.length, "Comment should not be blank"),
+}).omit({
+  id: true,
+  createdAt: true,
+});


### PR DESCRIPTION
- Created `proposal_comment` table.
- Created `comment_interaction` table to store votes on comment:
  - Unique constraint on `commentId` and `userKey`
  - Indexes on `commentId` and `commentId, voteType`
- Created `comment_digest` materialized view to aggregate votes:
  - Fields: `id`, `proposalId`, `userKey`, `content`, `createdAt`, `upvotes`, `downvotes`
  - Filters out deleted comments
  - Orders by `createdAt`